### PR TITLE
Rb193 enc params fixes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
 
   def toggle_div divs
     update_page do |page|
-      (divs.is_a?(Array) ? divs : divs.to_s).each do |div|
+      (divs.is_a?(Array) ? divs : divs.to_s).each_line do |div|
         # add jquery '#div' to the div if its missing
         div = div.to_s
         div = "##{div}" if div[0] != "#"

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -84,7 +84,7 @@ class Classification
     matches = []
     possible_value_orders.each do |rule|
       match = []
-      rule.each do |element|
+      rule.each_line do |element|
         match << "#{element}#{LookupKey::EQ_DELM}#{attr_to_value(element)}"
       end
       matches << match.join(LookupKey::KEY_DELM)

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -113,6 +113,14 @@ class LookupKey < ActiveRecord::Base
     super({:only => [:key, :is_param, :required, :override, :description, :default_value, :id]}.merge(options))
   end
 
+  def path_elements
+    path.split.map do |paths|
+      paths.split(KEY_DELM).map do |element|
+        element
+      end
+    end
+  end
+
   private
 
   # Generate possible lookup values type matches to a given host
@@ -139,14 +147,6 @@ class LookupKey < ActiveRecord::Base
     # fact attribute
     if (fn = host.fact_names.first(:conditions => { :name => element }))
       return FactValue.where(:host_id => host.id, :fact_name_id => fn.id).first.value
-    end
-  end
-
-  def path_elements
-    path.split.map do |paths|
-      paths.split(KEY_DELM).map do |element|
-        element
-      end
     end
   end
 


### PR DESCRIPTION
Two Ruby 1.9 fixes that seem to break the ENC when using class parameters:

<pre>
undefined method `each' for "fqdn":String

NoMethodError
undefined method `each' for "fqdn":String
app/models/classification.rb:87:in `block in path2matches'
app/models/classification.rb:85:in `each'
app/models/classification.rb:85:in `path2matches'
app/models/classification.rb:55:in `values_hash'
app/models/classification.rb:12:in `enc'
app/models/host.rb:724:in `lookup_keys_class_params'
app/models/host.rb:353:in `info'
app/controllers/hosts_controller.rb:166:in `block (2 levels) in externalNodes'
app/controllers/hosts_controller.rb:165:in `externalNodes'9
lib/foreman/threadsession.rb:31:in `clear_thread' 
</pre>


<pre>
private method `path_elements' called for #<LookupKey:0x00000003d9bec8> 

NoMethodError
private method `path_elements' called for #<LookupKey:0x00000003d9bec8>
app/models/classification.rb:47:in `map'
app/models/classification.rb:47:in `possible_value_orders'
app/models/classification.rb:85:in `path2matches'
app/models/classification.rb:55:in `values_hash'
app/models/classification.rb:12:in `enc'
app/models/host.rb:724:in `lookup_keys_class_params'
app/models/host.rb:353:in `info'
app/controllers/hosts_controller.rb:166:in `block (2 levels) in externalNodes'
app/controllers/hosts_controller.rb:165:in `externalNodes'
lib/foreman/threadsession.rb:31:in `clear_thread' 
</pre>
